### PR TITLE
fix(build): update places/scalable meson.build

### DIFF
--- a/places/scalable/meson.build
+++ b/places/scalable/meson.build
@@ -1,7 +1,6 @@
 scalable_places_iconsdir = join_paths(places_iconsdir, 'scalable')
 
 regular_files = [
-<<<<<<< Updated upstream
     # DO NOT REMOVE: Begining of regular segment
     'folder-backup-legacy.svg',
     'folder-backup.svg',


### PR DESCRIPTION
This PR fix build:

```sh
morewaita/places/scalable/meson.build:4:1: ERROR: Expecting rbracket got lt.
<<<<<<< Updated upstream
 ^
For a block that started at 3,16
regular_files = [
                ^
```